### PR TITLE
flutter hook sample code update

### DIFF
--- a/lib/hook/useDebugValue.dart
+++ b/lib/hook/useDebugValue.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+
+ValueNotifier useDebugValue(initialState, debugLabel) {
+  final state = useState(initialState);
+  print(debugLabel + ": " + initialState);
+  return state;
+}

--- a/lib/hook/useDebugValue.dart
+++ b/lib/hook/useDebugValue.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 
+// 함수로만 구성된 flutter custom hook - 단순 상태값만을 다루는 기초적인 hook
 ValueNotifier useDebugValue(initialState, debugLabel) {
   final state = useState(initialState);
   print(debugLabel + ": " + initialState);

--- a/lib/hook/useTabController.dart
+++ b/lib/hook/useTabController.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+
+// class로 상태를 한번 감싼 flutter custom hook - hook이 복잡해지고 라이프사이클 등을 다루는 다른 hook과 조합해야하는 경우
+TabController useTabController({required int length, int initialIndex = 0}) {
+  // use - Registers a Hook and returns its value.
+  // use must be called within the build method of either HookWidget or StatefulHookWidget.
+  // All calls of use must be made outside of conditional checks and always in the same order.
+  return use(TabControllerHook(length, initialIndex));
+}
+
+class TabControllerHook extends Hook<TabController> {
+  const TabControllerHook(this.length, this.initialIndex);
+
+  final int length;
+  final int initialIndex;
+
+  @override
+  HookState<TabController, TabControllerHook> createState() => _TabControllerHookState();
+}
+
+class _TabControllerHookState extends HookState<TabController, TabControllerHook> {
+  @override
+  TabController build(BuildContext context) {
+    final tickerProvider = useSingleTickerProvider(keys: [hook.length, hook.initialIndex]);
+
+    // 메모이제이션된 controller
+    final controller = useMemoized(
+        () => TabController(length: hook.length, vsync: tickerProvider, initialIndex: hook.initialIndex),
+        [tickerProvider]);
+
+    // 라이프사이클 등록
+    useEffect(() {
+      return controller.dispose;
+    }, [controller]);
+
+    // controller 제공
+    return controller;
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:sample_project/screen/splash_screen.dart';
+import 'package:sample_project/screen/default_animation_screen.dart';
+import 'package:sample_project/screen/default_counter_screen.dart';
+import 'package:sample_project/screen/hook_animation_screen.dart';
+import 'package:sample_project/screen/hook_counter_screen.dart';
 
 void main() => runApp(const MyApp());
 
@@ -30,13 +33,31 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0; // 상태 초기값
+  void goToDefaultAnimationScreen() {
+    Navigator.of(context).push(MaterialPageRoute(
+        builder: (context) => const DefaultAnimationScreen(
+            key: Key("DefaultAnimationScreen"),
+            duration: Duration(seconds: 1))));
+  }
 
-  void _incrementCounter() {
-    // 이거 없으면 build 실행안됨 -> 화면 업데이트 없음
-    // setState(() => _counter++);
-    Navigator.of(context)
-        .push(MaterialPageRoute(builder: (context) => const SplashScreen()));
+  void goToDefaultCounterScreen() {
+    Navigator.of(context).push(MaterialPageRoute(
+        builder: (context) => const DefaultCounterScreen(
+              key: Key("DefaultAnimationScreen"),
+            )));
+  }
+
+  void goToHookAnimationScreen() {
+    Navigator.of(context).push(MaterialPageRoute(
+        builder: (context) => const HookAnimationScreen(
+              key: Key("HookAnimationScreen"),
+            )));
+  }
+
+  void goToHookCounterScreen() {
+    Navigator.of(context).push(MaterialPageRoute(
+        builder: (context) =>
+            const HookCounterScreen(key: Key("HookCounterScreen"))));
   }
 
   @override
@@ -54,20 +75,24 @@ class _MyHomePageState extends State<MyHomePage> {
           // Antd Col과 유사함 - vertical align - 기본적으로 height 100% -> 부모 높이 - mainAxisAlignment flex랑 똑같음
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
-            const Text(
-              'You have pushed the button this many times:',
+            MaterialButton(
+              onPressed: goToDefaultAnimationScreen,
+              child: const Text("goToDefaultAnimationScreen"),
             ),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
+            MaterialButton(
+              onPressed: goToDefaultCounterScreen,
+              child: const Text("goToDefaultCounterScreen"),
+            ),
+            MaterialButton(
+              onPressed: goToHookAnimationScreen,
+              child: const Text("goToHookAnimationScreen"),
+            ),
+            MaterialButton(
+              onPressed: goToHookCounterScreen,
+              child: const Text("goToHookCounterScreen"),
             ),
           ],
         ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
       ),
     );
   }

--- a/lib/screen/default_animation_screen.dart
+++ b/lib/screen/default_animation_screen.dart
@@ -2,8 +2,7 @@ import 'package:flutter/material.dart';
 
 // 상태를 가지는 위젯 객체
 class DefaultAnimationScreen extends StatefulWidget {
-  const DefaultAnimationScreen({required Key key, required this.duration})
-      : super(key: key);
+  const DefaultAnimationScreen({required Key key, required this.duration}) : super(key: key);
   final Duration duration;
 
   @override
@@ -11,8 +10,7 @@ class DefaultAnimationScreen extends StatefulWidget {
 }
 
 // 상태 객체
-class _DefaultAnimationScreenState extends State<DefaultAnimationScreen>
-    with SingleTickerProviderStateMixin {
+class _DefaultAnimationScreenState extends State<DefaultAnimationScreen> with SingleTickerProviderStateMixin {
   // 상태 선언
   late AnimationController _controller;
   late Animation<double> _animation = CurvedAnimation(
@@ -96,8 +94,7 @@ class RaisedButton extends StatelessWidget {
   final Function() onPressed;
   final Widget child;
 
-  const RaisedButton({Key? key, required this.child, required this.onPressed})
-      : super(key: key);
+  const RaisedButton({Key? key, required this.child, required this.onPressed}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/screen/default_animation_screen.dart
+++ b/lib/screen/default_animation_screen.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+
+// 상태를 가지는 위젯 객체
+class DefaultAnimationScreen extends StatefulWidget {
+  const DefaultAnimationScreen({required Key key, required this.duration})
+      : super(key: key);
+  final Duration duration;
+
+  @override
+  State<DefaultAnimationScreen> createState() => _DefaultAnimationScreenState();
+}
+
+// 상태 객체
+class _DefaultAnimationScreenState extends State<DefaultAnimationScreen>
+    with SingleTickerProviderStateMixin {
+  // 상태 선언
+  late AnimationController _controller;
+  late Animation<double> _animation = CurvedAnimation(
+    parent: _controller,
+    curve: Curves.easeIn,
+  );
+
+  // AnimationController가 추가됨에 따라 위젯의 로직과 관계없는 라이프사이클 코드가 추가된다.
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(vsync: this, duration: widget.duration);
+    _animation = CurvedAnimation(
+      parent: _controller,
+      curve: Curves.easeIn,
+    );
+    _animation.addListener(() {
+      setState(() {});
+    });
+  }
+
+  @override
+  void didUpdateWidget(DefaultAnimationScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.duration != oldWidget.duration) {
+      _controller.duration = widget.duration;
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void goBack() {
+    Navigator.pop(context);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Column(mainAxisAlignment: MainAxisAlignment.center, children: [
+          RaisedButton(onPressed: goBack, child: const Text("GO BACK")),
+          Text(
+            'AnimationController value:${_animation.value.toStringAsFixed(2)}',
+          ),
+          const SizedBox(
+            height: 40,
+          ),
+          SizedBox(
+            height: _animation.value * 100,
+            width: _animation.value * 100,
+            child: const FlutterLogo(),
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: <Widget>[
+              RaisedButton(
+                child: const Text("forward"),
+                onPressed: () => _controller.forward(),
+              ),
+              RaisedButton(
+                child: const Text("stop"),
+                onPressed: () => _controller.stop(),
+              ),
+              RaisedButton(
+                child: const Text("reverse"),
+                onPressed: () => _controller.reverse(),
+              ),
+            ],
+          ),
+        ]),
+      ),
+    );
+  }
+}
+
+class RaisedButton extends StatelessWidget {
+  final Function() onPressed;
+  final Widget child;
+
+  const RaisedButton({Key? key, required this.child, required this.onPressed})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+        child: MaterialButton(
+      onPressed: onPressed,
+      child: child,
+    ));
+  }
+}

--- a/lib/screen/default_counter_screen.dart
+++ b/lib/screen/default_counter_screen.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:sample_project/screen/default_animation_screen.dart';
+
+// 상태를 가지는 위젯 객체
+class DefaultCounterScreen extends StatefulWidget {
+  const DefaultCounterScreen({required Key key}) : super(key: key);
+
+  @override
+  State<DefaultCounterScreen> createState() => _DefaultCounterScreenState();
+}
+
+// 상태 객체
+class _DefaultCounterScreenState extends State<DefaultCounterScreen> {
+  // 상태 선언
+  int counter = 0;
+
+  // 상태를 변경하는 매서드 선언 with setState
+  void onPress() {
+    setState(() {
+      counter++;
+    });
+  }
+
+  void goBack() {
+    Navigator.pop(context);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Column(mainAxisAlignment: MainAxisAlignment.center, children: [
+          RaisedButton(onPressed: goBack, child: const Text("GO BACK")),
+          Text("$counter"),
+          const SizedBox(
+            height: 40,
+          ),
+          GestureDetector(
+            onTap: onPress,
+            child: Container(
+              padding: const EdgeInsets.all(15),
+              child: const Text("+"),
+            ),
+          )
+        ]),
+      ),
+    );
+  }
+}

--- a/lib/screen/default_counter_screen.dart
+++ b/lib/screen/default_counter_screen.dart
@@ -16,14 +16,10 @@ class _DefaultCounterScreenState extends State<DefaultCounterScreen> {
 
   // 상태를 변경하는 매서드 선언 with setState
   void onPress() {
-    setState(() {
-      counter++;
-    });
+    setState(() => counter++);
   }
 
-  void goBack() {
-    Navigator.pop(context);
-  }
+  void goBack() => Navigator.pop(context);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/screen/hook_animation_screen.dart
+++ b/lib/screen/hook_animation_screen.dart
@@ -7,11 +7,9 @@ class HookAnimationScreen extends HookWidget {
 
   @override
   Widget build(BuildContext context) {
-    // 상태 선언 with ValueNotifier
-    final controller =
-        useAnimationController(duration: const Duration(seconds: 1));
-    final animation =
-        useAnimation(CurvedAnimation(parent: controller, curve: Curves.easeIn));
+    // 상태 선언 with ValueNotifier - flutter hook이 기본 제공하는 훅
+    final controller = useAnimationController(duration: const Duration(seconds: 1));
+    final animation = useAnimation(CurvedAnimation(parent: controller, curve: Curves.easeIn));
 
     useEffect(() {
       return () {
@@ -20,9 +18,7 @@ class HookAnimationScreen extends HookWidget {
       };
     }, []);
 
-    void goBack() {
-      Navigator.pop(context);
-    }
+    void goBack() => Navigator.pop(context);
 
     return Scaffold(
       body: Center(

--- a/lib/screen/hook_animation_screen.dart
+++ b/lib/screen/hook_animation_screen.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:sample_project/screen/default_animation_screen.dart';
+
+class HookAnimationScreen extends HookWidget {
+  const HookAnimationScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    // 상태 선언 with ValueNotifier
+    final controller =
+        useAnimationController(duration: const Duration(seconds: 1));
+    final animation =
+        useAnimation(CurvedAnimation(parent: controller, curve: Curves.easeIn));
+
+    useEffect(() {
+      return () {
+        // clean up code (dispose) ex) removeEventListener
+        controller.dispose();
+      };
+    }, []);
+
+    void goBack() {
+      Navigator.pop(context);
+    }
+
+    return Scaffold(
+      body: Center(
+        child: Column(mainAxisAlignment: MainAxisAlignment.center, children: [
+          RaisedButton(onPressed: goBack, child: const Text("GO BACK")),
+          Text(
+            'AnimationController value:${animation.toStringAsFixed(2)}',
+          ),
+          const SizedBox(
+            height: 40,
+          ),
+          SizedBox(
+            height: animation * 100,
+            width: animation * 100,
+            child: const FlutterLogo(),
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: <Widget>[
+              RaisedButton(
+                child: const Text("forward"),
+                onPressed: () => controller.forward(),
+              ),
+              RaisedButton(
+                child: const Text("stop"),
+                onPressed: () => controller.stop(),
+              ),
+              RaisedButton(
+                child: const Text("reverse"),
+                onPressed: () => controller.reverse(),
+              ),
+            ],
+          ),
+        ]),
+      ),
+    );
+  }
+}

--- a/lib/screen/hook_counter_screen.dart
+++ b/lib/screen/hook_counter_screen.dart
@@ -20,9 +20,7 @@ class HookCounterScreen extends HookWidget {
       };
     }, [counter.value]);
 
-    void goBack() {
-      Navigator.pop(context);
-    }
+    void goBack() => Navigator.pop(context);
 
     return Scaffold(
       body: Center(

--- a/lib/screen/hook_counter_screen.dart
+++ b/lib/screen/hook_counter_screen.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:sample_project/screen/default_animation_screen.dart';
+
+class HookCounterScreen extends HookWidget {
+  const HookCounterScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    // 상태 선언 with ValueNotifier
+    final counter = useState(0);
+
+    useEffect(() {
+      if (counter.value > 5) {
+        final value = counter.value;
+        print("counter is greater than 5 => counter: $value");
+      }
+      return () {
+        // clean up code (dispose) ex) removeEventListener
+      };
+    }, [counter.value]);
+
+    void goBack() {
+      Navigator.pop(context);
+    }
+
+    return Scaffold(
+      body: Center(
+        child: Column(mainAxisAlignment: MainAxisAlignment.center, children: [
+          RaisedButton(onPressed: goBack, child: const Text("GO BACK")),
+          Text("${counter.value}"),
+          const SizedBox(
+            height: 40,
+          ),
+          GestureDetector(
+            onTap: () => counter.value++,
+            child: Container(
+              padding: const EdgeInsets.all(15),
+              child: const Text("+"),
+            ),
+          )
+        ]),
+      ),
+    );
+  }
+}

--- a/lib/screen/splash_screen.dart
+++ b/lib/screen/splash_screen.dart
@@ -8,7 +8,7 @@ class SplashScreen extends StatelessWidget {
     return Scaffold(
       body: Container(
         color: Colors.red,
-        child: Text('asd'),
+        child: const Text('asd'),
       ),
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -62,6 +62,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_hooks:
+    dependency: "direct main"
+    description:
+      name: flutter_hooks
+      sha256: "6a126f703b89499818d73305e4ce1e3de33b4ae1c5512e3b8eab4b986f46774c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.18.6"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -186,3 +194,4 @@ packages:
     version: "2.1.4"
 sdks:
   dart: ">=3.0.1 <4.0.0"
+  flutter: ">=3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
+  flutter_hooks: ^0.18.6
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
[작업목적]

플러터 앱에서 상태관리를 리액트 훅과 유사한 방식으로 관리하여 상태과 뷰 컴포넌트를 구분하여 관리하는 아키텍처 검토

패키지 주소 : https://pub.dev/packages/flutter_hooks 



- Hook은 위젯의 build 함수 안 최상단에서만 선언되며, 기존 리액트와 유사하게 조건문이나 다른 하위 레벨의 스코프에서 불러올 수 없다. (use 함수도 마찬가지)

- 상태관리, 라이프사이클, 메모이제이션, Future, Controller 등 다양한 비즈니스 로직 (위젯의 UI 선언 로직을 제외한)을 다룰 수 있다.

- 단순 상태값을 다루는 함수형 hook과 라이프사이클이나 다른 hook과 연계되는 커스텀훅을 다루는 클래스형 hook이 있다.